### PR TITLE
WEB-1660: useRefinementList sends only 20 values by default when clic…

### DIFF
--- a/components/product/AlgoliaFacets/CustomRefinementList.tsx
+++ b/components/product/AlgoliaFacets/CustomRefinementList.tsx
@@ -61,6 +61,7 @@ function CustomRefinementList({ attribute, searchableAttributes }: CustomRefinem
       attribute,
       showMore: true,
       limit: 6,
+      showMoreLimit: 100, //useRefinementList sends only 20 values by default when clicking “View More”, so I increased the limit to 100 using the showMoreLimit attribute.
     })
 
   const [query, setQuery] = useState('')


### PR DESCRIPTION
- Increased the limit to 100 using the showMoreLimit attribute to fix the facet displaying to limit 20 only