### PR TITLE
fix: fetch accurate inventory info for schema offer availability (WEB-1676)

### DIFF
--- a/lib/api/operations/get-product-search-variations.ts
+++ b/lib/api/operations/get-product-search-variations.ts
@@ -65,6 +65,32 @@ export default async function getProductSearchVariations(
         inventoryInfo: (product as any).inventoryInfo ?? null,
       }
     })
+
+    // productSearch doesn't return live inventory — fall back to individual product queries
+    // for any variant where inventoryInfo is missing or onlineStockAvailable is null
+    const inventoryFallbacks = result
+      .filter((v) => !v.inventoryInfo || (v.inventoryInfo as any).onlineStockAvailable == null)
+      .map((v) =>
+        fetcher(
+          {
+            query: getProductVariationQuery,
+            variables: { productCode, variationProductCode: v.variationProductCode },
+          },
+          { headers }
+        )
+          .then((res) => ({
+            variationProductCode: v.variationProductCode,
+            inventoryInfo: res.data?.product?.inventoryInfo ?? null,
+          }))
+          .catch(() => null)
+      )
+
+    const inventoryResults = await Promise.all(inventoryFallbacks)
+    for (const inv of inventoryResults) {
+      if (!inv) continue
+      const variant = result.find((v) => v.variationProductCode === inv.variationProductCode)
+      if (variant) variant.inventoryInfo = inv.inventoryInfo
+    }
   } else {
     console.log('Entered else statement')
     result = []

--- a/lib/gql/queries/get-product-variation.ts
+++ b/lib/gql/queries/get-product-variation.ts
@@ -5,6 +5,10 @@ const getProductVariationQuery = /* GraphQL */ `
       price {
         price
       }
+      inventoryInfo {
+        onlineStockAvailable
+        outOfStockBehavior
+      }
       properties {
         attributeFQN
         attributeDetail {

--- a/lib/utils/generate-schema-markup.ts
+++ b/lib/utils/generate-schema-markup.ts
@@ -457,12 +457,11 @@ function generateProductSchema(
         return url.startsWith('//') ? `https:${url}` : url
       }) || []
 
-  // Build offers — one per sellable variation
+  // Build offers — only for Bethyl products
+  const isBethyl = brandSlug.toLowerCase().includes('bethyl')
   const offers: Array<Record<string, any>> = []
 
-  const isBethyl = brandSlug.toLowerCase().includes('bethyl')
-
-  if (productVariations && productVariations.length > 0) {
+  if (isBethyl && productVariations && productVariations.length > 0) {
     for (const variant of productVariations) {
       const variantCode = variant.variationProductCode
       if (!variantCode) continue
@@ -475,7 +474,7 @@ function generateProductSchema(
           variantLabel,
           variantCode,
           `${productUrl}?selected=${variantCode}`,
-          isBethyl ? (variant as any).price?.price : undefined,
+          (variant as any).price?.price,
           variant.inventoryInfo,
           organizationId
         )


### PR DESCRIPTION
1. productSearch API does not return live inventory data, causing all schema Offer entries to show OutOfStock regardless of actual stock levels
2. Added inventoryInfo { onlineStockAvailable outOfStockBehavior } to getProductVariationQuery — it was missing entirely, meaning the else branch also had no inventory data
3. After the productSearch batch call in getProductSearchVariations, variants with null onlineStockAvailable now trigger individual product queries in parallel to fetch accurate live inventory
4. Fallback only fires for variants where inventory is missing — no unnecessary extra calls when search returns valid data